### PR TITLE
Remove 12ga Shell Ammobox translation

### DIFF
--- a/zscript.zsc
+++ b/zscript.zsc
@@ -1,33 +1,33 @@
 version "4.10.0"
 
 // Vanilla Loadout Codes
-const LEGACY_HDLD_355BOX            = "3bx";
-const LEGACY_HDLD_4MMBOX            = "zbx";
-const LEGACY_HDLD_7MMBOX            = "abx";
-const LEGACY_HDLD_9MMBOX            = "9bx";
-const LEGACY_HDLD_RKTBOX            = "rbx";
-const LEGACY_HDLD_SHELLBOX          = "sbx";
+const HDLD_REUSABLE_355_BOX            = "3bx";
+const HDLD_REUSABLE_4MM_BOX            = "zbx";
+const HDLD_REUSABLE_7MM_BOX            = "abx";
+const HDLD_REUSABLE_9MM_BOX            = "9bx";
+const HDLD_REUSABLE_RKT_BOX            = "rbx";
+const HDLD_REUSABLE_SHELL_BOX          = "sbx";
 
 // HDBulletLib Loadout Codes
-const LEGACY_HDLD_4GSHELLBOX        = "4bx";
-const LEGACY_HDLD_4GSLUGBOX         = "gbx";
-const LEGACY_HDLD_500HBOX           = "hbx";
-const LEGACY_HDLD_500LBOX           = "lbx";
-const LEGACY_HDLD_5MMBOX            = "bbx";
-const LEGACY_HDLD_069BOX            = "ybx";
-const LEGACY_HDLD_420BOX            = "ibx";
-const LEGACY_HDLD_45ACPBOX          = "pbx";
-const LEGACY_HDLD_45LCBOX           = "cbx";
-const LEGACY_HDLD_50AEBOX           = "ebx";
-const LEGACY_HDLD_50AMBOX           = "tbx";
-const LEGACY_HDLD_6MMFLECHETTEBOX   = "6bx";
-const LEGACY_HDLD_10MMBOX           = "0bx";
-const LEGACY_HDLD_FLAREBOX          = "fbx";
-const LEGACY_HDLD_LESSLETHALBOX     = "dbx";
-const LEGACY_HDLD_3006BOX           = "mbx";
-const LEGACY_HDLD_50OMGBOX          = "obx";
-const LEGACY_HDLD_SLUGBOX           = "ubx";
-const LEGACY_HDLD_EXPLOSIVESHELLBOX = "xbx";
+const HDLD_REUSABLE_4GSHELL_BOX        = "4bx";
+const HDLD_REUSABLE_4GSLUG_BOX         = "gbx";
+const HDLD_REUSABLE_500H_BOX           = "hbx";
+const HDLD_REUSABLE_500L_BOX           = "lbx";
+const HDLD_REUSABLE_5MM_BOX            = "bbx";
+const HDLD_REUSABLE_069_BOX            = "ybx";
+const HDLD_REUSABLE_420_BOX            = "ibx";
+const HDLD_REUSABLE_45ACP_BOX          = "pbx";
+const HDLD_REUSABLE_45LC_BOX           = "cbx";
+const HDLD_REUSABLE_50AE_BOX           = "ebx";
+const HDLD_REUSABLE_50AM_BOX           = "tbx";
+const HDLD_REUSABLE_6MMFLECHETTE_BOX   = "6bx";
+const HDLD_REUSABLE_10MM_BOX           = "0bx";
+const HDLD_REUSABLE_FLARE_BOX          = "fbx";
+const HDLD_REUSABLE_LESSLETHAL_BOX     = "dbx";
+const HDLD_REUSABLE_3006_BOX           = "mbx";
+const HDLD_REUSABLE_50OMG_BOX          = "obx";
+const HDLD_REUSABLE_SLUG_BOX           = "ubx";
+const HDLD_REUSABLE_EXPLOSIVESHELL_BOX = "xbx";
 
 // Base Classes
 #include "zscript/reusableAmmoBox.zs"

--- a/zscript/HDBulletLib/069Box.zs
+++ b/zscript/HDBulletLib/069Box.zs
@@ -1,4 +1,4 @@
-class Legacy_069Box : ReusableAmmobox {
+class Reusable069Box : ReusableAmmobox {
 	default {
 		scale 0.5;
 
@@ -8,7 +8,7 @@ class Legacy_069Box : ReusableAmmobox {
 
 		tag "$TAG_069_BOX";
 		Inventory.pickupMessage "$PICKUP_069_BOX";
-		HDPickup.refId LEGACY_HDLD_069BOX;
+		HDPickup.refId HDLD_REUSABLE_069_BOX;
 
 		ReusableAmmobox.fullSprite "42BXA0";
 		ReusableAmmobox.emptySprite "42BXW0";

--- a/zscript/HDBulletLib/10mmBox.zs
+++ b/zscript/HDBulletLib/10mmBox.zs
@@ -1,4 +1,4 @@
-class Legacy_10mmBox : ReusableAmmobox {
+class Reusable10mmBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_10mmBox : ReusableAmmobox {
 
 		tag "$TAG_10MM_BOX";
 		Inventory.pickupMessage "$PICKUP_10MM_BOX";
-		HDPickup.refId LEGACY_HDLD_10MMBOX;
+		HDPickup.refId HDLD_REUSABLE_10MM_BOX;
 
 		ReusableAmmobox.fullSprite "BX10A0";
 		ReusableAmmobox.emptySprite "BX10W0";

--- a/zscript/HDBulletLib/3006Box.zs
+++ b/zscript/HDBulletLib/3006Box.zs
@@ -1,4 +1,4 @@
-class Legacy_3006Box : ReusableAmmobox {
+class Reusable3006Box : ReusableAmmobox {
 	default {
 		xscale 0.5;
 		yscale 0.4;
@@ -9,7 +9,7 @@ class Legacy_3006Box : ReusableAmmobox {
 
 		tag "$TAG_3006_BOX";
 		Inventory.pickupMessage "$PICKUP_3006_BOX";
-		HDPickup.refId LEGACY_HDLD_3006BOX;
+		HDPickup.refId HDLD_REUSABLE_3006_BOX;
 
 		ReusableAmmobox.fullSprite "M1A1Y0";
 		ReusableAmmobox.emptySprite "M1A1W0";

--- a/zscript/HDBulletLib/420Box.zs
+++ b/zscript/HDBulletLib/420Box.zs
@@ -1,4 +1,4 @@
-class Legacy_420Box : ReusableAmmobox {
+class Reusable420Box : ReusableAmmobox {
 	default {
 		scale 0.5;
 
@@ -8,7 +8,7 @@ class Legacy_420Box : ReusableAmmobox {
 
 		tag "$TAG_420_BOX";
 		Inventory.pickupMessage "$PICKUP_420_BOX";
-		HDPickup.refId LEGACY_HDLD_420BOX;
+		HDPickup.refId HDLD_REUSABLE_420_BOX;
 
 		ReusableAmmobox.fullSprite "420AA0";
 		ReusableAmmobox.emptySprite "420AW0";

--- a/zscript/HDBulletLib/45ACPBox.zs
+++ b/zscript/HDBulletLib/45ACPBox.zs
@@ -1,4 +1,4 @@
-class Legacy_45ACPBox : ReusableAmmobox {
+class Reusable45ACPBox : ReusableAmmobox {
 	default {
 		XScale 0.40;
 		YScale 0.40;
@@ -9,7 +9,7 @@ class Legacy_45ACPBox : ReusableAmmobox {
 
 		tag "$TAG_45ACP_BOX";
 		Inventory.pickupMessage "$PICKUP_45ACP_BOX";
-		HDPickup.refId LEGACY_HDLD_45ACPBOX;
+		HDPickup.refId HDLD_REUSABLE_45ACP_BOX;
 
 		ReusableAmmobox.fullSprite "45BXA0";
 		ReusableAmmobox.emptySprite "45BXW0";

--- a/zscript/HDBulletLib/45LCBox.zs
+++ b/zscript/HDBulletLib/45LCBox.zs
@@ -1,4 +1,4 @@
-class Legacy_45LCBox : ReusableAmmobox {
+class Reusable45LCBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_45LCBox : ReusableAmmobox {
 
 		tag "$TAG_45LC_BOX";
 		Inventory.pickupMessage "$PICKUP_45LC_BOX";
-		HDPickup.refId LEGACY_HDLD_45LCBOX;
+		HDPickup.refId HDLD_REUSABLE_45LC_BOX;
 
 		ReusableAmmobox.fullSprite "45LBA0";
 		ReusableAmmobox.emptySprite "45LBW0";

--- a/zscript/HDBulletLib/4GaShellBox.zs
+++ b/zscript/HDBulletLib/4GaShellBox.zs
@@ -1,4 +1,4 @@
-class Legacy_4gaShellBox : ReusableAmmobox {
+class Reusable4gaShellBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_4gaShellBox : ReusableAmmobox {
 
 		tag "$TAG_4G_SHELL_BOX";
 		Inventory.pickupMessage "$PICKUP_4G_SHELL_BOX";
-		HDPickup.refId LEGACY_HDLD_4GSHELLBOX;
+		HDPickup.refId HDLD_REUSABLE_4GSHELL_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "4GBXA0";

--- a/zscript/HDBulletLib/4GaSlugBox.zs
+++ b/zscript/HDBulletLib/4GaSlugBox.zs
@@ -1,4 +1,4 @@
-class Legacy_4gaSlugBox : ReusableAmmobox {
+class Reusable4gaSlugBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_4gaSlugBox : ReusableAmmobox {
 
 		tag "$TAG_4G_SLUG_BOX";
 		Inventory.pickupMessage "$PICKUP_4G_SLUG_BOX";
-		HDPickup.refId LEGACY_HDLD_4GSLUGBOX;
+		HDPickup.refId HDLD_REUSABLE_4GSLUG_BOX;
 
 		ReusableAmmobox.extractMax 2;
 		ReusableAmmobox.fullSprite "4GBXA0";

--- a/zscript/HDBulletLib/500HeavyBox.zs
+++ b/zscript/HDBulletLib/500HeavyBox.zs
@@ -1,4 +1,4 @@
-class Legacy_500HeavyBox : ReusableAmmobox {
+class Reusable500HeavyBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_500HeavyBox : ReusableAmmobox {
 
 		tag "$TAG_500_HEAVY_BOX";
 		Inventory.pickupMessage "$PICKUP_500_HEAVY_BOX";
-		HDPickup.refId LEGACY_HDLD_500HBOX;
+		HDPickup.refId HDLD_REUSABLE_500H_BOX;
 
 		ReusableAmmobox.fullSprite "5HBXA0";
 		ReusableAmmobox.emptySprite "5HBXW0";

--- a/zscript/HDBulletLib/500LightBox.zs
+++ b/zscript/HDBulletLib/500LightBox.zs
@@ -1,4 +1,4 @@
-class Legacy_500LightBox : ReusableAmmobox {
+class Reusable500LightBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_500LightBox : ReusableAmmobox {
 
 		tag "$TAG_500_LIGHT_BOX";
 		Inventory.pickupMessage "$PICKUP_500_LIGHT_BOX";
-		HDPickup.refId LEGACY_HDLD_500LBOX;
+		HDPickup.refId HDLD_REUSABLE_500L_BOX;
 
 		ReusableAmmobox.fullSprite "5LBXA0";
 		ReusableAmmobox.emptySprite "5LBXW0";

--- a/zscript/HDBulletLib/50AEBox.zs
+++ b/zscript/HDBulletLib/50AEBox.zs
@@ -1,4 +1,4 @@
-class Legacy_50AEBox : ReusableAmmobox {
+class Reusable50AEBox : ReusableAmmobox {
 	default {
 		scale 0.32;
 
@@ -8,7 +8,7 @@ class Legacy_50AEBox : ReusableAmmobox {
 
 		tag "$TAG_50AE_BOX";
 		Inventory.pickupMessage "$PICKUP_50AE_BOX";
-		HDPickup.refId LEGACY_HDLD_50AEBOX;
+		HDPickup.refId HDLD_REUSABLE_50AE_BOX;
 
 		ReusableAmmobox.fullSprite "50AEX0";
 		ReusableAmmobox.emptySprite "50AEW0";

--- a/zscript/HDBulletLib/50AMBox.zs
+++ b/zscript/HDBulletLib/50AMBox.zs
@@ -1,4 +1,4 @@
-class Legacy_50AMBox : ReusableAmmobox {
+class Reusable50AMBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_50AMBox : ReusableAmmobox {
 
 		tag "$TAG_50AM_BOX";
 		Inventory.pickupMessage "$PICKUP_50AM_BOX";
-		HDPickup.refId LEGACY_HDLD_50AMBOX;
+		HDPickup.refId HDLD_REUSABLE_50AM_BOX;
 
 		ReusableAmmobox.fullSprite "50AMX0";
 		ReusableAmmobox.emptySprite "50AMV0";

--- a/zscript/HDBulletLib/50OMGBox.zs
+++ b/zscript/HDBulletLib/50OMGBox.zs
@@ -1,4 +1,4 @@
-class Legacy_50OMGBox : ReusableAmmobox {
+class Reusable50OMGBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_50OMGBox : ReusableAmmobox {
 
 		tag "$TAG_50OMG_BOX";
 		Inventory.pickupMessage "$PICKUP_50OMG_BOX";
-		HDPickup.refId LEGACY_HDLD_50OMGBOX;
+		HDPickup.refId HDLD_REUSABLE_50OMG_BOX;
 
 		ReusableAmmobox.fullSprite "OGBXA0";
 		ReusableAmmobox.emptySprite "OGBXW0";

--- a/zscript/HDBulletLib/5mmBox.zs
+++ b/zscript/HDBulletLib/5mmBox.zs
@@ -1,4 +1,4 @@
-class Legacy_5mmBox : ReusableAmmobox {
+class Reusable5mmBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_5mmBox : ReusableAmmobox {
 
 		tag "$TAG_5MM_BOX";
 		Inventory.pickupMessage "$PICKUP_5MM_BOX";
-		HDPickup.refId LEGACY_HDLD_5MMBOX;
+		HDPickup.refId HDLD_REUSABLE_5MM_BOX;
 
 		ReusableAmmobox.extractMax 16;
 		ReusableAmmobox.fullSprite "5MBXA0";

--- a/zscript/HDBulletLib/6mmBox.zs
+++ b/zscript/HDBulletLib/6mmBox.zs
@@ -1,4 +1,4 @@
-class Legacy_6mmBox : ReusableAmmobox {
+class Reusable6mmBox : ReusableAmmobox {
 	default {
 		scale 0.3;
 
@@ -11,7 +11,7 @@ class Legacy_6mmBox : ReusableAmmobox {
 
 		tag "$TAG_6MM_BOX";
 		Inventory.pickupMessage "$PICKUP_6MM_BOX";
-		HDPickup.refId LEGACY_HDLD_6MMFLECHETTEBOX;
+		HDPickup.refId HDLD_REUSABLE_6MMFLECHETTE_BOX;
 
 		ReusableAmmobox.extractMax 12;
 		ReusableAmmobox.fullSprite "ACRPK0";

--- a/zscript/HDBulletLib/explosiveShellBox.zs
+++ b/zscript/HDBulletLib/explosiveShellBox.zs
@@ -1,4 +1,4 @@
-class Legacy_ExplosiveShellBox : ReusableAmmobox {
+class ReusableExplosiveShellBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_ExplosiveShellBox : ReusableAmmobox {
 
 		tag "$TAG_EXPLOSIVE_SHELL_BOX";
 		Inventory.pickupMessage "$PICKUP_EXPLOSIVE_SHELL_BOX";
-		HDPickup.refId LEGACY_HDLD_EXPLOSIVESHELLBOX;
+		HDPickup.refId HDLD_REUSABLE_EXPLOSIVESHELL_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "XLBXA0";

--- a/zscript/HDBulletLib/flareBox.zs
+++ b/zscript/HDBulletLib/flareBox.zs
@@ -1,4 +1,4 @@
-class Legacy_FlareBox : ReusableAmmobox {
+class ReusableFlareBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_FlareBox : ReusableAmmobox {
 
 		tag "$TAG_FLARE_BOX";
 		Inventory.pickupMessage "$PICKUP_FLARE_BOX";
-		HDPickup.refId LEGACY_HDLD_FLAREBOX;
+		HDPickup.refId HDLD_REUSABLE_FLARE_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "FLBXA0";

--- a/zscript/HDBulletLib/lessLethalBox.zs
+++ b/zscript/HDBulletLib/lessLethalBox.zs
@@ -1,4 +1,4 @@
-class Legacy_LessLethalBox : ReusableAmmobox {
+class ReusableLessLethalBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_LessLethalBox : ReusableAmmobox {
 
 		tag "$TAG_LESSLETHAL_BOX";
 		Inventory.pickupMessage "$PICKUP_LESSLETHAL_BOX";
-		HDPickup.refId LEGACY_HDLD_LESSLETHALBOX;
+		HDPickup.refId HDLD_REUSABLE_LESSLETHAL_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "LLBXA0";

--- a/zscript/HDBulletLib/slugBox.zs
+++ b/zscript/HDBulletLib/slugBox.zs
@@ -1,4 +1,4 @@
-class Legacy_SlugBox : ReusableAmmobox {
+class ReusableSlugBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_SlugBox : ReusableAmmobox {
 
 		tag "$TAG_SLUG_BOX";
 		Inventory.pickupMessage "$PICKUP_SLUG_BOX";
-		HDPickup.refId LEGACY_HDLD_SLUGBOX;
+		HDPickup.refId HDLD_REUSABLE_SLUG_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "SLBXA0";

--- a/zscript/Vanilla/355Box.zs
+++ b/zscript/Vanilla/355Box.zs
@@ -1,4 +1,4 @@
-class Legacy_355Box : ReusableAmmobox {
+class Reusable355Box : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_355Box : ReusableAmmobox {
 
 		tag "$TAG_355_BOX";
 		Inventory.pickupMessage "$PICKUP_355_BOX";
-		HDPickup.refId LEGACY_HDLD_355BOX;
+		HDPickup.refId HDLD_REUSABLE_355_BOX;
 
 		ReusableAmmobox.fullSprite "3BOXA0";
 		ReusableAmmobox.emptySprite "3BOXW0";

--- a/zscript/Vanilla/7mmBox.zs
+++ b/zscript/Vanilla/7mmBox.zs
@@ -1,4 +1,4 @@
-class Legacy_7mmBox : ReusableAmmobox {
+class Reusable7mmBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_7mmBox : ReusableAmmobox {
 
 		tag "$TAG_7MM_BOX";
 		Inventory.pickupMessage "$PICKUP_7MM_BOX";
-		HDPickup.refId LEGACY_HDLD_7MMBOX;
+		HDPickup.refId HDLD_REUSABLE_7MM_BOX;
 
 		ReusableAmmobox.fullSprite "7BOXA0";
 		ReusableAmmobox.emptySprite "7BOXW0";

--- a/zscript/Vanilla/9mmBox.zs
+++ b/zscript/Vanilla/9mmBox.zs
@@ -1,4 +1,4 @@
-class Legacy_9mmBox : ReusableAmmobox {
+class Reusable9mmBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -8,7 +8,7 @@ class Legacy_9mmBox : ReusableAmmobox {
 
 		tag "$TAG_9MM_BOX";
 		Inventory.pickupMessage "$PICKUP_9MM_BOX";
-		HDPickup.refId LEGACY_HDLD_9MMBOX;
+		HDPickup.refId HDLD_REUSABLE_9MM_BOX;
 
 		ReusableAmmobox.fullSprite "9BOXA0";
 		ReusableAmmobox.emptySprite "9BOXW0";

--- a/zscript/Vanilla/rocketBox.zs
+++ b/zscript/Vanilla/rocketBox.zs
@@ -1,4 +1,4 @@
-class Legacy_RocketBox : ReusableAmmobox {
+class ReusableRocketBox : ReusableAmmobox {
 	default {
 		scale 0.6;
 
@@ -12,7 +12,7 @@ class Legacy_RocketBox : ReusableAmmobox {
 
 		tag "$TAG_RPG_BOX";
 		Inventory.pickupMessage "$PICKUP_RPG_BOX";
-		HDPickup.refId LEGACY_HDLD_RKTBOX;
+		HDPickup.refId HDLD_REUSABLE_RKT_BOX;
 
 		ReusableAmmobox.extractMax 1;
 		ReusableAmmobox.fullSprite "RBOXA0";

--- a/zscript/Vanilla/shellBox.zs
+++ b/zscript/Vanilla/shellBox.zs
@@ -11,7 +11,6 @@ class Legacy_ShellBox : ReusableAmmobox {
 
 		tag "$TAG_SHELL_BOX";
 		Inventory.pickupMessage "$PICKUP_SHELL_BOX";
-		translation "160:167=80:105";
 		HDPickup.refId LEGACY_HDLD_SHELLBOX;
 
 		ReusableAmmobox.extractMax 4;

--- a/zscript/Vanilla/shellBox.zs
+++ b/zscript/Vanilla/shellBox.zs
@@ -1,4 +1,4 @@
-class Legacy_ShellBox : ReusableAmmobox {
+class ReusableShellBox : ReusableAmmobox {
 	default {
 		scale 0.4;
 
@@ -11,7 +11,7 @@ class Legacy_ShellBox : ReusableAmmobox {
 
 		tag "$TAG_SHELL_BOX";
 		Inventory.pickupMessage "$PICKUP_SHELL_BOX";
-		HDPickup.refId LEGACY_HDLD_SHELLBOX;
+		HDPickup.refId HDLD_REUSABLE_SHELL_BOX;
 
 		ReusableAmmobox.extractMax 4;
 		ReusableAmmobox.fullSprite "SBOXA0";

--- a/zscript/spawnReplacer.zs
+++ b/zscript/spawnReplacer.zs
@@ -86,7 +86,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_9mm.push("HushPuppyPistol");
 		wep_9mm.push("MinervaChaingun");
 		wep_9mm.push("TenMilAutoReloadingThingy");
-		addAmmo("Legacy_9mmBox", wep_9mm);
+		addAmmo("Reusable9mmBox", wep_9mm);
 
 		Array<string> wep_355;
 		wep_355.push("HDColt355");
@@ -95,7 +95,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_355.push("HDRevolver");
 		wep_355.push("HDScopedRevolver");
 		wep_355.push("HDSnubNoseReolver");
-		addAmmo("Legacy_355Box", wep_355);
+		addAmmo("Reusable355Box", wep_355);
 
 		Array<string> wep_shell;
 		wep_shell.push("Bossmerg");
@@ -114,7 +114,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_shell.push("SawedSlayer");
 		wep_shell.push("ScopedSlayer");
 		wep_shell.push("Slayer");
-		addAmmo("Legacy_ShellBox", wep_shell);
+		addAmmo("ReusableShellBox", wep_shell);
 
 		Array<string> wep_7mm;
 		wep_7mm.push("AutoReloader");
@@ -129,7 +129,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_7mm.push("LiberatorRifle");
 		wep_7mm.push("NoScopeBoss");
 		wep_7mm.push("ObrozzPistol");
-		addAmmo("Legacy_7mmBox", wep_7mm);
+		addAmmo("Reusable7mmBox", wep_7mm);
 
 		Array<string> wep_rocket;
 		wep_rocket.push("Blooper");
@@ -141,27 +141,27 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_rocket.push("HDTROGRifle");
 		wep_rocket.push("IronsLiberatorRifle");
 		wep_rocket.push("HDChinaLake");
-		addAmmo("Legacy_RocketBox", wep_rocket);
+		addAmmo("ReusableRocketBox", wep_rocket);
 
 		Array<string> wep_4GaShell;
 		wep_4GaShell.push("");
-		addAmmo("Legacy_4GaShellBox", wep_4GaShell);
+		addAmmo("Reusable4GaShellBox", wep_4GaShell);
 
 		Array<string> wep_5mm;
 		wep_5mm.push("BossRifleButItsFuckingPink");
 		wep_5mm.push("HD_M5165");
 		wep_5mm.push("HD_Ruger1022");
-		addAmmo("Legacy_5mmBox", wep_5mm);
+		addAmmo("Reusable5mmBox", wep_5mm);
 
 		Array<string> wep_6mm;
 		wep_6mm.push("HD_SteyrACR");
-		addAmmo("Legacy_6mmBox", wep_6mm);
+		addAmmo("Reusable6mmBox", wep_6mm);
 
 		Array<string> wep_10mm;
 		wep_10mm.push("HD10mmPistol");
 		wep_10mm.push("HDSigCow");
 		wep_10mm.push("TenMilAutoReloadingThingy");
-		addAmmo("Legacy_10mmBox", wep_10mm);
+		addAmmo("Reusable10mmBox", wep_10mm);
 
 		Array<string> wep_45ACP;
 		wep_45ACP.push("HDMAC10");
@@ -169,61 +169,61 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_45ACP.push("HDUMP");
 		wep_45ACP.push("HDUSP");
 		wep_45ACP.push("HDColt1911");
-		addAmmo("Legacy_45ACPBox", wep_45ACP);
+		addAmmo("Reusable45ACPBox", wep_45ACP);
 
 		Array<string> wep_45LC;
 		wep_45LC.push("HDSingleActionRevolver");
-		addAmmo("Legacy_45LCBox", wep_45LC);
+		addAmmo("Reusable45LCBox", wep_45LC);
 
 		Array<string> wep_50AE;
 		wep_50AE.push("HDViper");
-		addAmmo("Legacy_50AEBox", wep_50AE);
+		addAmmo("Reusable50AEBox", wep_50AE);
 
 		Array<string> wep_50AM;
 		wep_50AM.push("HDLeverGun");
 		wep_50AM.push("HD_AutoMag");
-		addAmmo("Legacy_50AMBox", wep_50AM);
+		addAmmo("Reusable50AMBox", wep_50AM);
 
 		Array<string> wep_50OMG;
 		wep_50OMG.push("BogRifle");
 		wep_50OMG.push("HDM2HB");
 		wep_50OMG.push("HDWyvern");
 		wep_50OMG.push("ZM94Rifle");
-		addAmmo("Legacy_50OMGBox", wep_50OMG);
+		addAmmo("Reusable50OMGBox", wep_50OMG);
 
 		Array<string> wep_069;
 		wep_069.push("HDAurochs");
-		addAmmo("Legacy_069Box", wep_069);
+		addAmmo("Reusable069Box", wep_069);
 
 		Array<string> wep_420;
 		wep_420.push("HDAurochs");
-		addAmmo("Legacy_420Box", wep_420);
+		addAmmo("Reusable420Box", wep_420);
 
 		Array<string> wep_500Heavy;
 		wep_500Heavy.push("HDOtisGun");
-		addAmmo("Legacy_500HeavyBox", wep_500Heavy);
+		addAmmo("Reusable500HeavyBox", wep_500Heavy);
 
 		Array<string> wep_500Light;
 		wep_500Light.push("HDOtisGun");
-		addAmmo("Legacy_500LightBox", wep_500Light);
+		addAmmo("Reusable500LightBox", wep_500Light);
 
 		Array<string> wep_3006;
 		wep_3006.push("M1Garand");
-		addAmmo("Legacy_3006Box", wep_3006);
+		addAmmo("Reusable3006Box", wep_3006);
 
 		Array<string> wep_explosiveShell;
 		wep_explosiveShell.push("ExplosiveHunter");
 		wep_explosiveShell.push("MetalFireBlooper");
-		addAmmo("Legacy_ExplosiveShellBox", wep_explosiveShell);
+		addAmmo("ReusableExplosiveShellBox", wep_explosiveShell);
 
 		Array<string> wep_flare;
 		wep_flare.push("FireBlooper");
 		wep_flare.push("MetalFireBlooper");
-		addAmmo("Legacy_FlareBox", wep_flare);
+		addAmmo("ReusableFlareBox", wep_flare);
 
 		Array<string> wep_lessLethal;
 		wep_lessLethal.push("LLHunter");
-		addAmmo("Legacy_LessLethalBox", wep_lessLethal);
+		addAmmo("ReusableLessLethalBox", wep_lessLethal);
 
 		Array<string> wep_slug;
 		wep_slug.push("HDAltis");
@@ -232,40 +232,40 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		wep_slug.push("HDGreely");
 		wep_slug.push("HDPDFour");
 		wep_slug.push("HDSix12");
-		addAmmo("Legacy_SlugBox", wep_slug);
+		addAmmo("ReusableSlugBox", wep_slug);
 
 		// --------------------
 		// Vanilla Ammoboxes
 		// --------------------
 
-		addItem("HD9mBoxPickup",   "Legacy_9mmBox",    "HDPistolAmmo",   10, "TEN9A0", "PRNDA0");
-		addItem("ShellBoxPickup",  "Legacy_ShellBox",  "HDShellAmmo",    4,  "SHELA0", "SHL1A0");
-		addItem("HD7mBoxPickup",   "Legacy_7mmBox",    "HDSevenMilAmmo", 10, "TEN7A0", "7RNDA0");
-		addItem("HD355BoxPickup",  "Legacy_355Box",    "HDRevolverAmmo", 10, "TEN9A0", "PRNDA0");
-		addItem("RocketBigPickup", "Legacy_RocketBox", "HDRocketAmmo",   1,  "ROQPA0", "ROQPA0");
+		addItem("HD9mBoxPickup",   "Reusable9mmBox",    "HDPistolAmmo",   10, "TEN9A0", "PRNDA0");
+		addItem("ShellBoxPickup",  "ReusableShellBox",  "HDShellAmmo",    4,  "SHELA0", "SHL1A0");
+		addItem("HD7mBoxPickup",   "Reusable7mmBox",    "HDSevenMilAmmo", 10, "TEN7A0", "7RNDA0");
+		addItem("HD355BoxPickup",  "Reusable355Box",    "HDRevolverAmmo", 10, "TEN9A0", "PRNDA0");
+		addItem("RocketBigPickup", "ReusableRocketBox", "HDRocketAmmo",   1,  "ROQPA0", "ROQPA0");
 
 		// --------------------
 		// HDBulletLib Ammoboxes
 		// --------------------
 
-		addItem("HD4GBBox",                "Legacy_4gaSlugBox",        "HD4GBAmmo",            4,  "4GPAA0", "4GS1A0");
-		addItem("PB_5mmBoxPickup",         "Legacy_5mmBox",            "HD5mm_Ammo",           16, "5MMYA0", "5MMZA0");
-		addItem("HD6mmFlechetteBoxPickup", "Legacy_6mmBox",            "HD6mmFlechetteAmmo",   12, "ACR9I0", "ACRPI0");
-		addItem("HD10mBoxPickup",          "Legacy_10mmBox",           "HD10mAmmo",            10, "T10MA0", "PR10A0");
-		addItem("HD45ACPBoxPickup",        "Legacy_45ACPBox",          "HD45ACPAmmo",          10, "45TN",   "45RN");
-		addItem("HD45LCBoxPickup",         "Legacy_45LCBox",           "HD45LCAmmo",           10, "TN45A0", "RN45A0");
-		addItem("HD50AEBoxPickup",         "Legacy_50AEBox",           "HD50AEAmmo",           10, "TEN9A0", "PRNDA0");
-		addItem("PB_50AMBoxPickup",        "Legacy_50AMBox",           "HD50AM_Ammo",          10, "G50YA0", "G50ZA0");
-		addItem("HD50OMGBoxPickup",        "Legacy_50OMGBox",          "HD50OMGAmmo",          10, "OG10A0", "OGBLA0");
-		addItem("HD069BoreBox",            "Legacy_069Box",            "HD069BoreAmmo",        10, "42BTA0", "42BRA0");
-		addItem("HD420BoxPickup",          "Legacy_420Box",            "HDAurochsAmmo",        10, "42TEA0", "420BA0");
-		addItem("HD500SWHeavyBoxPickup",   "Legacy_500HeavyBox",       "HD500SWHeavyAmmo",     10, "TNSWB0", "SWRNB0");
-		addItem("HD500SWLightBoxPickup",   "Legacy_500LightBox",       "HD500SWLightAmmo",     10, "TNSWA0", "SWRNA0");
-		addItem("HD3006BoxPickup",         "Legacy_3006Box",           "ThirtyAughtSixAmmo",   10, "TEN7A0", "7RNDA0");
-		addItem("ExplosiveShellBoxPickup", "Legacy_ExplosiveShellBox", "HDExplosiveShellAmmo", 4,  "XLS4A0", "XLS1A0");
-		addItem("FlareShellBoxPickup",     "Legacy_FlareBox",          "HDFlareAmmo",          4,  "FLA4A0", "FLARA0");
-		addItem("LLShellBoxPickup",        "Legacy_LessLethalBox",     "HDLLShellAmmo",        4,  "LLS4A0", "LLS1A0");
-		addItem("SlugBoxPickup",           "Legacy_SlugBox",           "HDSlugAmmo",           4,  "SLUGA0", "SLG1A0");
+		addItem("HD4GBBox",                "Reusable4gaSlugBox",        "HD4GBAmmo",            4,  "4GPAA0", "4GS1A0");
+		addItem("PB_5mmBoxPickup",         "Reusable5mmBox",            "HD5mm_Ammo",           16, "5MMYA0", "5MMZA0");
+		addItem("HD6mmFlechetteBoxPickup", "Reusable6mmBox",            "HD6mmFlechetteAmmo",   12, "ACR9I0", "ACRPI0");
+		addItem("HD10mBoxPickup",          "Reusable10mmBox",           "HD10mAmmo",            10, "T10MA0", "PR10A0");
+		addItem("HD45ACPBoxPickup",        "Reusable45ACPBox",          "HD45ACPAmmo",          10, "45TN",   "45RN");
+		addItem("HD45LCBoxPickup",         "Reusable45LCBox",           "HD45LCAmmo",           10, "TN45A0", "RN45A0");
+		addItem("HD50AEBoxPickup",         "Reusable50AEBox",           "HD50AEAmmo",           10, "TEN9A0", "PRNDA0");
+		addItem("PB_50AMBoxPickup",        "Reusable50AMBox",           "HD50AM_Ammo",          10, "G50YA0", "G50ZA0");
+		addItem("HD50OMGBoxPickup",        "Reusable50OMGBox",          "HD50OMGAmmo",          10, "OG10A0", "OGBLA0");
+		addItem("HD069BoreBox",            "Reusable069Box",            "HD069BoreAmmo",        10, "42BTA0", "42BRA0");
+		addItem("HD420BoxPickup",          "Reusable420Box",            "HDAurochsAmmo",        10, "42TEA0", "420BA0");
+		addItem("HD500SWHeavyBoxPickup",   "Reusable500HeavyBox",       "HD500SWHeavyAmmo",     10, "TNSWB0", "SWRNB0");
+		addItem("HD500SWLightBoxPickup",   "Reusable500LightBox",       "HD500SWLightAmmo",     10, "TNSWA0", "SWRNA0");
+		addItem("HD3006BoxPickup",         "Reusable3006Box",           "ThirtyAughtSixAmmo",   10, "TEN7A0", "7RNDA0");
+		addItem("ExplosiveShellBoxPickup", "ReusableExplosiveShellBox", "HDExplosiveShellAmmo", 4,  "XLS4A0", "XLS1A0");
+		addItem("FlareShellBoxPickup",     "ReusableFlareBox",          "HDFlareAmmo",          4,  "FLA4A0", "FLARA0");
+		addItem("LLShellBoxPickup",        "ReusableLessLethalBox",     "HDLLShellAmmo",        4,  "LLS4A0", "LLS1A0");
+		addItem("SlugBoxPickup",           "ReusableSlugBox",           "HDSlugAmmo",           4,  "SLUGA0", "SLG1A0");
 	}
 
 	void addAmmo(string name, Array<string> weapons) {


### PR DESCRIPTION
With the recent commits mentioned in #6, it seems this should not be needed in the class definition any longer.  As shown below, my personal reskin simply defines a new TEXTURES lump with the existing vanilla sprite and thus because I alter the definition the translation from HDest doesn't apply and the brass-end comes back.

![image](https://github.com/HDest-Community/reusable-ammoboxes/assets/6988914/8128ba1a-c08e-4fa9-9efa-bc00dea2b983)
