### PR TITLE
Fix 4ga Shell Box reference

### DIFF
--- a/zscript/spawnReplacer.zs
+++ b/zscript/spawnReplacer.zs
@@ -144,7 +144,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		addAmmo("ReusableRocketBox", wep_rocket);
 
 		Array<string> wep_4GaShell;
-		wep_4GaShell.push("");
+		wep_4GaShell.push("HD4GBBlaster");
 		addAmmo("Reusable4GaShellBox", wep_4GaShell);
 
 		Array<string> wep_5mm;

--- a/zscript/spawnReplacer.zs
+++ b/zscript/spawnReplacer.zs
@@ -248,7 +248,7 @@ class ReusableAmmoboxesSpawner : EventHandler {
 		// HDBulletLib Ammoboxes
 		// --------------------
 
-		addItem("HD4GBBox",                "Reusable4gaSlugBox",        "HD4GBAmmo",            4,  "4GPAA0", "4GS1A0");
+		addItem("HD4GBBox",                "Reusable4gaShellBox",       "HD4GBAmmo",            4,  "4GPAA0", "4GS1A0");
 		addItem("PB_5mmBoxPickup",         "Reusable5mmBox",            "HD5mm_Ammo",           16, "5MMYA0", "5MMZA0");
 		addItem("HD6mmFlechetteBoxPickup", "Reusable6mmBox",            "HD6mmFlechetteAmmo",   12, "ACR9I0", "ACRPI0");
 		addItem("HD10mBoxPickup",          "Reusable10mmBox",           "HD10mAmmo",            10, "T10MA0", "PR10A0");


### PR DESCRIPTION
Tested by loading the Nora 4ga Squad Shotgun and having it not throw the error, as well as spawn the weapon with the ammunition.  Also it should now be registered as a weapon that uses the reusable ammobox, so it shouldn't purge the box from your inventory either.

Closes #10.