### PR TITLE
Add Spawn Replacer for RocketBox w/ H.E.A.T. round

### DIFF
--- a/zscript/ReusableAmmoboxes/Vanilla/rocketBox.zs
+++ b/zscript/ReusableAmmoboxes/Vanilla/rocketBox.zs
@@ -52,3 +52,14 @@ class ReusableRocketBox : ReusableAmmobox {
 			stop;
 	}
 }
+
+class ReusableBigRocketBox : IdleDummy {
+	override void PostBeginPlay() {
+		super.PostBeginPlay();
+
+		let ofs = AngleToVector(angle);
+
+		Spawn('ReusableRocketBox', pos, ALLOW_REPLACE);
+		Spawn('HEATAmmo', (pos.xy + ofs * 10, pos.z), ALLOW_REPLACE);
+	}
+}

--- a/zscript/ReusableAmmoboxes/Vanilla/rocketBox.zs
+++ b/zscript/ReusableAmmoboxes/Vanilla/rocketBox.zs
@@ -52,14 +52,3 @@ class ReusableRocketBox : ReusableAmmobox {
 			stop;
 	}
 }
-
-class ReusableBigRocketBox : IdleDummy {
-	override void PostBeginPlay() {
-		super.PostBeginPlay();
-
-		let ofs = AngleToVector(angle);
-
-		Spawn('ReusableRocketBox', pos, ALLOW_REPLACE);
-		Spawn('HEATAmmo', (pos.xy + ofs * 10, pos.z), ALLOW_REPLACE);
-	}
-}

--- a/zscript/ReusableAmmoboxes/spawnReplacer.zs
+++ b/zscript/ReusableAmmoboxes/spawnReplacer.zs
@@ -355,12 +355,12 @@ class ReusableAmmoboxesSpawner : EventHandler {
         // Vanilla Ammoboxes
         // --------------------
 
-        addItem('HD9mBoxPickup',   'Reusable9mmBox',       'HDPistolAmmo',   10, 'TEN9A0', 'PRNDA0');
-        addItem('ShellBoxPickup',  'ReusableShellBox',     'HDShellAmmo',    4,  'SHELA0', 'SHL1A0');
-        addItem('HD7mBoxPickup',   'Reusable7mmBox',       'SevenMilAmmo',   10, 'TEN7A0', '7RNDA0');
-        addItem('HD355BoxPickup',  'Reusable355Box',       'HDRevolverAmmo', 10, 'TEN9A0', 'PRNDA0');
-        addItem('RocketBigPickup', 'ReusableBigRocketBox', 'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
-        addItem('RocketBoxPickup', 'ReusableRocketBox',    'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
+        addItem('HD9mBoxPickup',   'Reusable9mmBox',    'HDPistolAmmo',   10, 'TEN9A0', 'PRNDA0');
+        addItem('ShellBoxPickup',  'ReusableShellBox',  'HDShellAmmo',    4,  'SHELA0', 'SHL1A0');
+        addItem('HD7mBoxPickup',   'Reusable7mmBox',    'SevenMilAmmo',   10, 'TEN7A0', '7RNDA0');
+        addItem('HD355BoxPickup',  'Reusable355Box',    'HDRevolverAmmo', 10, 'TEN9A0', 'PRNDA0');
+        addItem('RocketBigPickup', 'ReusableRocketBox', 'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
+        addItem('RocketBoxPickup', 'ReusableRocketBox', 'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
 
         // --------------------
         // HDBulletLib Ammoboxes
@@ -521,14 +521,23 @@ class ReusableAmmoboxesSpawner : EventHandler {
         // Iterate through the list of ammo candidates for spawned item.
         foreach (itemSpawn : itemSpawnList) {
             if (itemSpawn.spawnName ~== candidateName) {
-                let p = HDRoundAmmo(Actor.spawn(itemSpawn.ammoName, item.pos));
+                let r = Actor.spawn(itemSpawn.ammoName, item.pos);
+                let p = HDRoundAmmo(r);
 
-                p.amount = item.amount;
-                p.vel = item.vel;
+                if (p) {
+                    // If we can split the rounds, do so
+                    p.amount = item.amount;
+                    p.vel = item.vel;
 
-                p.splitPickupBoxableRound(itemSpawn.bundleSize, -1, candidateName, itemSpawn.bundleSprite, itemSpawn.roundSprite);
+                    p.splitPickupBoxableRound(itemSpawn.bundleSize, -1, candidateName, itemSpawn.bundleSprite, itemSpawn.roundSprite);
 
-                item.destroy();
+                    item.destroy();
+                } else {
+                    // Otherwise, just replace the box
+                    handleMapSpawns(item, candidateName);
+
+                    r.destroy();
+                }
 
                 return;
             }

--- a/zscript/ReusableAmmoboxes/spawnReplacer.zs
+++ b/zscript/ReusableAmmoboxes/spawnReplacer.zs
@@ -355,11 +355,12 @@ class ReusableAmmoboxesSpawner : EventHandler {
         // Vanilla Ammoboxes
         // --------------------
 
-        addItem('HD9mBoxPickup',   'Reusable9mmBox',    'HDPistolAmmo',   10, 'TEN9A0', 'PRNDA0');
-        addItem('ShellBoxPickup',  'ReusableShellBox',  'HDShellAmmo',    4,  'SHELA0', 'SHL1A0');
-        addItem('HD7mBoxPickup',   'Reusable7mmBox',    'SevenMilAmmo',   10, 'TEN7A0', '7RNDA0');
-        addItem('HD355BoxPickup',  'Reusable355Box',    'HDRevolverAmmo', 10, 'TEN9A0', 'PRNDA0');
-        addItem('RocketBigPickup', 'ReusableRocketBox', 'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
+        addItem('HD9mBoxPickup',   'Reusable9mmBox',       'HDPistolAmmo',   10, 'TEN9A0', 'PRNDA0');
+        addItem('ShellBoxPickup',  'ReusableShellBox',     'HDShellAmmo',    4,  'SHELA0', 'SHL1A0');
+        addItem('HD7mBoxPickup',   'Reusable7mmBox',       'SevenMilAmmo',   10, 'TEN7A0', '7RNDA0');
+        addItem('HD355BoxPickup',  'Reusable355Box',       'HDRevolverAmmo', 10, 'TEN9A0', 'PRNDA0');
+        addItem('RocketBigPickup', 'ReusableBigRocketBox', 'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
+        addItem('RocketBoxPickup', 'ReusableRocketBox',    'HDRocketAmmo',   1,  'ROQPA0', 'ROQPA0');
 
         // --------------------
         // HDBulletLib Ammoboxes


### PR DESCRIPTION
Since the RocketBigPickup was split into a simple RocketBoxPickup as well as a combo box + H.E.A.T. round, we might as well add a dummy spawner to mimic that behavior, but with the reusable box.

Fixes #32.